### PR TITLE
wrong jar file name and missing dependency

### DIFF
--- a/asm-monitor/src/main/bin/encryptPassword.sh
+++ b/asm-monitor/src/main/bin/encryptPassword.sh
@@ -43,7 +43,7 @@ HP-UX)
 esac
 
 # the command to start the EPAgent
-EpaCmd="java -cp lib/EPAgent.jar:lib/ca.apm.swat.asm-monitor.jar com.ca.apm.swat.epaplugins.utils.CryptoUtils $1"
+EpaCmd="java -cp lib/EPAgent.jar:lib/com.ca.apm.extensions.epagent.asm-monitor.jar:lib/commons-codec-1.10.jar com.ca.apm.swat.epaplugins.utils.CryptoUtils $1"
 # ||||||||||||||||||||   END CONFIGURATION SECTION  ||||||||||||||||||||
 
 cd "${WILYHOME}"


### PR DESCRIPTION
I believe that the wrong name comes from older versions of the fieldpack (this name is still present in the build.xml file though). Also, the commons library was missing from the classpath and the encrypt operation failed.